### PR TITLE
Fix MCP server startup errors with Claude Desktop

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2346,8 +2346,10 @@ class SmartTRAServer {
         this.isConnected = false;
         process.exit(0);
       } else {
-        // Re-throw other uncaught exceptions
-        throw error;
+        // Log other uncaught exceptions and exit
+        // Never re-throw from uncaughtException handler as it causes undefined behavior
+        console.error('Uncaught exception:', error);
+        process.exit(1);
       }
     });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,15 +7,14 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { QueryParser, ParsedQuery } from './query-parser.js';
+import * as fs from 'fs';
+import * as path from 'path';
 
-// Load environment variables before any other imports
-// Using process.env directly instead of dotenv to avoid stdout pollution
-// The .env file will be loaded by the dotenv/config import in package.json or manually
+// Load environment variables before any other code
+// Using manual parsing instead of dotenv to avoid stdout pollution
+// The dotenv package outputs to stdout which corrupts MCP JSON-RPC protocol
 if (process.env.NODE_ENV !== 'production') {
   try {
-    // Use native fs to read .env file to avoid dotenv stdout pollution
-    const fs = await import('fs');
-    const path = await import('path');
     const envPath = path.join(process.cwd(), '.env');
     if (fs.existsSync(envPath)) {
       const envContent = fs.readFileSync(envPath, 'utf-8');
@@ -33,7 +32,8 @@ if (process.env.NODE_ENV !== 'production') {
       });
     }
   } catch (error) {
-    // Silently ignore .env loading errors
+    // Silently ignore .env loading errors to avoid stdout pollution
+    // Errors will be caught when trying to use the missing env vars
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes two critical startup errors that prevented the MCP server from working properly with Claude Desktop:

1. **EPIPE errors** when Claude Desktop disconnects during initialization
2. **JSON-RPC protocol corruption** from dotenv stdout output

## Problems Fixed

### 1. EPIPE Error (Write to Broken Pipe)
- **Issue**: Server crashed with `Error: write EPIPE` when Claude Desktop disconnected during startup
- **Solution**: Added comprehensive error handling and connection state tracking

### 2. Dotenv Stdout Pollution
- **Issue**: dotenv package output corrupted JSON-RPC protocol causing `Unexpected token 'd', "[dotenv@17."... is not valid JSON`
- **Solution**: Replaced dotenv with manual .env parsing to ensure clean stdout

## Changes Made

### EPIPE Error Handling
- Added `isConnected` property to track transport connection state
- Implemented uncaught exception handler for EPIPE errors
- Added transport `onclose` and `onerror` handlers for graceful shutdown
- Protected station data loading to check connection state before operations
- Only log messages when connection is still active

### Dotenv Fix
- Removed `dotenv.config()` call that was polluting stdout
- Implemented manual .env file parsing using native fs module
- Ensures first output line is valid JSON for MCP protocol compliance

## Testing

- [x] Server starts without EPIPE errors
- [x] First output line is valid JSON (no dotenv pollution)
- [x] Successfully connects to Claude Desktop
- [x] All MCP tools remain functional

## Test Plan

1. Start the server with `npm run dev`
2. Verify clean JSON output without dotenv messages
3. Test with Claude Desktop - should connect without errors
4. Verify all three tools (search_trains, search_station, plan_trip) work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)