### PR TITLE
fix(api): upgrade all TDX APIs to v3

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1581,7 +1581,7 @@ class SmartTRAServer {
       const token = await this.getAccessToken();
       const baseUrl = process.env.TDX_BASE_URL || 'https://tdx.transportdata.tw/api/basic';
       
-      const response = await this.fetchWithRetry(`${baseUrl}/v2/Rail/TRA/Station?%24format=JSON`, {
+      const response = await this.fetchWithRetry(`${baseUrl}/v3/Rail/TRA/Station?%24format=JSON`, {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Accept': 'application/json'


### PR DESCRIPTION
## Summary
- Upgraded station API endpoint from v2 to v3 for consistency
- All TDX API calls now use v3 version uniformly
- Improves API compatibility and maintainability

## Changes
- Changed `/v2/Rail/TRA/Station` to `/v3/Rail/TRA/Station` in `src/server.ts`

## Test plan
- [x] Code compiles successfully (`npm run build`)
- [x] No syntax errors detected
- [x] Verified no remaining v2 API usage in codebase
- [ ] Manual testing with Claude Desktop to verify station search functionality

🤖 Generated with [Claude Code](https://claude.ai/code)